### PR TITLE
[import] Check for and use existing module imports for type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 *~
 .mypy_cache/
 .tox
+/.idea
+.dmypy.json

--- a/typewriter/fixes/fix_annotate_docs.py
+++ b/typewriter/fixes/fix_annotate_docs.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from lib2to3 import pytree
-from lib2to3.fixer_util import syms
+from lib2to3.fixer_util import does_tree_import, syms
 from lib2to3.pgen2 import token
 from lib2to3.pytree import Node
 from typing import Any, Dict, List, Match, Optional, Tuple, cast
@@ -152,14 +152,13 @@ class FixAnnotateDocs(BaseFixAnnotateFromSignature):
     def should_skip(self, node, results):
         return False
 
-    def type_updater(self, match):
-        # type: (Match) -> str
+    def type_updater(self, match, node):
+        # type: (Match, Node) -> str
         # Replace `pkg.mod.SomeClass` with `SomeClass`
         # and remember to import it.
         word = match.group()
         # Assume it's either builtin or from `typing`
-        if word in typing_all:
-            self.add_import('typing', word)
+        self.touch_typing_import(word, node)
         return word
 
     def make_annotation(self, node, results):
@@ -232,6 +231,6 @@ class FixAnnotateDocs(BaseFixAnnotateFromSignature):
                 if not is_method or keep_arg(i, arg_name, typ):
                     arg_types.append(kind + _get_type(typ).strip('*'))
 
-        arg_types = [self.update_type_names(arg_type) for arg_type in arg_types]
-        ret_type = self.update_type_names(ret_type)
+        arg_types = [self.update_type_names(arg_type, node) for arg_type in arg_types]
+        ret_type = self.update_type_names(ret_type, node)
         return arg_types, ret_type

--- a/typewriter/fixes/fixer_utils.py
+++ b/typewriter/fixes/fixer_utils.py
@@ -1,0 +1,135 @@
+"""
+Typewriter specific fixer utility functions
+"""
+
+from lib2to3.fixer_util import (FromImport, Leaf, Newline, Node,
+                                does_tree_import, find_root, is_import, syms,
+                                token)
+from typing import Optional
+
+
+def type_by_import_stmt(package, name, node):
+    # type: (str, str, Node) -> Optional[str]
+    """
+    Return name that needs to be annotated based on available imports
+
+    Parameters
+    -------------
+    package : str
+    name : str
+        Name of type being imported
+    node : Node
+
+    Returns
+    -------------
+    Optional[str]
+        Returns valid name for type if current import statement exists, or None is there is no
+        import statement
+    """
+    root = find_root(node)
+
+    if does_tree_import(package, name, root):
+        # name is being imported directly in the form of
+        # from <package> import <name>
+        return name
+
+    if does_tree_import(None, package, root):
+        # Mod is being imported in the form of
+        # import <package>
+        return '.'.join((package, name))
+
+    return None  # return None to signal there is not yet an import statement
+
+
+def create_import(package, name, node):
+    # type: (str, str, Node) -> None
+    """
+    Create import statement of the form `from <package> import <name>`
+
+    Parameters
+    -------------
+    package : str
+    name : str
+        Name of type being imported
+    node : Node
+    """
+
+    def is_import_stmt(node):
+        return (node.type == syms.simple_stmt and node.children and
+                is_import(node.children[0]))
+
+    root = find_root(node)
+
+    # figure out where to insert the new import.  First try to find
+    # the first import and then skip to the last one.
+    insert_pos = offset = 0
+    for idx, node in enumerate(root.children):
+        if not is_import_stmt(node):
+            continue
+        for offset, node2 in enumerate(root.children[idx:]):
+            if not is_import_stmt(node2):
+                break
+        insert_pos = idx + offset
+        break
+
+    # if there are no imports where we can insert, find the docstring.
+    # if that also fails, we stick to the beginning of the file
+    if insert_pos == 0:
+        for idx, node in enumerate(root.children):
+            if (node.type == syms.simple_stmt and node.children and
+                    node.children[0].type == token.STRING):
+                insert_pos = idx + 1
+                break
+
+    if package is None:
+        import_ = Node(syms.import_name, [
+            Leaf(token.NAME, "import"),
+            Leaf(token.NAME, name, prefix=" ")
+        ])
+    else:
+        import_ = FromImport(package, [Leaf(token.NAME, name, prefix=" ")])
+
+    children = [import_, Newline()]
+    root.insert_child(insert_pos, Node(syms.simple_stmt, children))
+
+
+def touch_import(package, name, node):
+    # type: (str, str, Node) -> str
+    """
+    Almost the same as lib2to3/fixer_util's touch_import, but broken into helper functions.
+    The difference between the lib2to3's function and ours is that this function assumes a
+    statement of the form:
+        `import mod`
+    is a sufficient import for type `mod.Name`.
+
+    To not obfuscate which type of import statement currently exists (and by proxy which form the
+    typename needs to be written in to be valid), we return the valid form of the typename.
+
+    So for the example above, touch_import would return
+        `mod.Name`
+    but if instead there was an import statement of the form
+        `from mod import Name`
+    then this function would simply return
+        `Name`
+
+    Parameters
+    -------------
+    package : str
+    name : str
+        Name of the type being imported
+    node : Node
+
+    Return
+    -------------
+    str
+        The typename that will be defined by either the already existing or created import
+        statement
+    """
+    result = type_by_import_stmt(package, name, node)
+
+    if result is not None:
+        # If there is already an import statement
+        return result
+
+    create_import(package, name, node)
+    return name

--- a/typewriter/fixes/tests/base_py2.py
+++ b/typewriter/fixes/tests/base_py2.py
@@ -203,6 +203,30 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             """
         self.check(a, b)
 
+    def test_type_by_import(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "mod2.AnotherClass"},
+              }])
+        a = """\
+            import mod2
+            def nop(foo):
+                return mod2.AnotherClass()
+            class MyClass: pass
+            """
+        b = """\
+            import mod2
+            def nop(foo):
+                # type: (MyClass) -> mod2.AnotherClass
+                return mod2.AnotherClass()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
     def test_add_kwds(self):
         self.setTestData(
             [{"func_name": "nop",


### PR DESCRIPTION
If we want to annotate type `Name` from `mod` and there exists the import statement:
`import mod`
then we will annotate `mod.Name` rather than add the import statement
`from mod import Name`