### PR TITLE
[import] Check type suggestions against import aliases

### DIFF
--- a/typewriter/fixes/fixer_utils.py
+++ b/typewriter/fixes/fixer_utils.py
@@ -2,10 +2,11 @@
 Typewriter specific fixer utility functions
 """
 
+from functools import cache
 from lib2to3.fixer_util import (FromImport, Leaf, Newline, Node,
-                                does_tree_import, find_root, is_import, syms,
-                                token)
-from typing import Optional
+                                does_tree_import, find_root, is_import,
+                                make_suite, syms, token)
+from typing import Dict, NamedTuple, Optional, Set, Union
 
 
 def type_by_import_stmt(package, name, node):
@@ -28,17 +29,28 @@ def type_by_import_stmt(package, name, node):
     """
     root = find_root(node)
 
-    if does_tree_import(package, name, root):
+    import_info = find_import_info(package, name, root)
+
+    if import_info:
         # name is being imported directly in the form of
         # from <package> import <name>
-        return name
+        return import_info.binding
 
-    if does_tree_import(None, package, root):
-        # Mod is being imported in the form of
-        # import <package>
-        return '.'.join((package, name))
+    split_path = package.rsplit('.', 1)
+    if len(split_path) > 1:
+        # We have a package of the form 'pkg.mod'
+        pkg = split_path[0]
+        mod = split_path[1]
+    else:
+        # We have a package of the form 'mod'
+        pkg = ''
+        mod = package
+    module_import_info = find_import_info(pkg, mod, root)
 
-    return None  # return None to signal there is not yet an import statement
+    if module_import_info:
+        return '.'.join((module_import_info.binding, name))
+
+    return None
 
 
 def create_import(package, name, node):
@@ -133,3 +145,207 @@ def touch_import(package, name, node):
 
     create_import(package, name, node)
     return name
+
+
+_block_syms = {syms.funcdef, syms.classdef, syms.trailer}
+
+
+def _find(name, node):
+    nodes = [node]
+    while nodes:
+        node = nodes.pop()
+        if node.type > 256 and node.type not in _block_syms:
+            nodes.extend(node.children)
+        elif node.type == token.NAME and node.value.strip() == name:
+            return node
+    return None
+
+
+ImportPairing = NamedTuple("ImportPairing", [
+    ("entry", str),
+    ("binding_name", str)
+])
+
+ImportNodeInfo = NamedTuple("ImportNodeInfo", [
+    ("imports", Dict[str, Set[ImportPairing]]),
+    ("node", Node)
+])
+
+ImportInfo = NamedTuple("ImportInfo", [
+    ("entry", str),
+    ("package", str),
+    ("binding", str)
+])
+
+
+def find_import_info(package, name, node):
+    # type: (str, str, Node) -> Optional[ImportInfo]
+    """
+    Finds the import statement for <name> regardless of whether <name> is the binding name
+        ex where name='a':
+        import a => match AND import a as b => match BUT import b as a => None
+
+    Parameters
+    -----------
+    package : str
+    name : str
+    node : Node
+
+    Return
+    -----------
+    Optional[ImportInfo]
+    """
+    for child in node.children:
+        if is_import(child):
+            ret = get_import_info(child)
+            imports = ret.imports.get(package)
+            if imports is None:
+                return None
+            import_ = next((x for x in imports if x.entry == name), None)
+            if import_:
+                return ImportInfo(import_.entry, package, import_.binding_name)
+        elif child.type == syms.simple_stmt:
+            res = find_import_info(package, name, child)
+            if res is None:
+                continue
+            else:
+                return res
+    return None
+
+
+def decompose_name(node):
+    """
+    NOTE: Per the lib2to3 grammar:
+            dotted_name: NAME ('.' NAME)*
+          This means that dotted_name can be either dotted or not dotted, i.e. it's a generalized
+          form of NAME. So this function will cover both cases.
+
+    Given a dotted_name node this will return a tuple of the form (pkg, name, full_string) where
+    all are str
+        ex: a.b.c => (a.b, c, a.b.c)
+            b.c => (b, c, b.c)
+            c => (None, c, c)
+    otherwise it will return None for each field
+    """
+    if node.type == token.NAME:
+        # node is just a name, no dots
+        return '', node.value, node.value
+
+    if node.children:
+        # Right most node will be the name, i.e. a.b.c = ['a','.','b','.','c']
+        name_node = node.children[-1]
+        package_nodes = node.children[:-2]
+        name = str(name_node).strip()
+        package = ''.join(str(n).strip() for n in package_nodes)
+        full = ''.join(str(n).strip() for n in node.children)
+        return package, name, full
+
+    return None, None, None
+
+
+def get_import_info(node):
+    """
+    Wraps the cachable get_import_info in order to convert the node into a hashable node before
+    attempting to cache
+    """
+    node = HashableNode(node)
+    return _get_import_info_cachable(node)
+
+
+class HashableNode(object):
+    """
+    Hashable wrapper for node and leaf objects in order to cache
+    """
+
+    def __init__(self, node):
+        # type: (Union[Node, Leaf]) -> None
+        """
+        Parameters
+        -----------
+        node : Union[Node, Leaf]
+        """
+        self.node = node
+
+    def __hash__(self):
+        return hash((self.node.get_lineno(),
+                     self.node.depth(),
+                     self.node.__str__()))
+
+
+@cache
+def _get_import_info_cachable(hashable_node):
+    # type: (HashableNode) -> ImportNodeInfo
+    """
+    We cache using hashable_node as a key and analyze hashable_node.node
+
+    If node is a valid import_stmt, this will return a named tuple for each component of the
+    statement
+        ex: from a.b import c as d, e  => (imports={'a.b': [(import_name='c',
+                                                             binding_name='d'),
+                                                            (import_name='e',
+                                                             binding_name='e')]},
+                                           node=node)
+
+    Since we will regularly iterate over the list import node for their information when
+    searching for binding or import matches, we cache the results of this function for
+    quick and non-redundant lookups
+
+    Parameters
+    -----------
+    hashable_node : HashableNode
+
+    Return
+    -----------
+    ImportNodeInfo
+    """
+    # Get the node from the hashable_node wrapper
+    node = hashable_node.node
+
+    def handle_name(node):
+        if node.type in (syms.dotted_as_name, syms.import_as_name):
+            # [Grammar] dotted_as_name: dotted_name ['as' NAME]
+            package = import_name = binding_name = None
+            name = node.children[0]
+            binding_name = str(node.children[2]).strip()
+            if name.type in (syms.dotted_name, token.NAME):
+                # [Grammar] dotted_name: NAME ('.' NAME)*
+                # We don't need the third field since we know the alias will be the binding_name
+                package, import_name, _ = decompose_name(name)
+            return package, import_name, binding_name
+        # If there was no "as", we know this is dotted_name
+        # [Grammar] dotted_name: NAME ('.' NAME)*
+        return decompose_name(node)
+
+    package = None
+    imports = dict()  # type: Dict[str, Set[ImportPairing]]
+    if node.type == syms.import_name:
+        # [Grammar]: import_name: 'import' dotted_as_names
+        as_name = node.children[1]
+        if as_name.type in (syms.dotted_as_names, syms.import_as_names):
+            # [Grammar]: dotted_as_names: dotted_as_name (',' dotted_as_name)*
+            as_names = [child for child in as_name.children if str(child).strip() != ',']
+        else:
+            as_names = [as_name]
+        for child in as_names:
+            package, import_name, binding_name = handle_name(child)
+            imports.setdefault(package, set()).add(ImportPairing(import_name, binding_name))
+    elif node.type == syms.import_from:
+        # [Grammar]:
+        # import_from: ('from' ('.'* dotted_name | '.'+)
+        #   'import' ('*' | '(' import_as_names ')' | import_as_names))
+        package = str(node.children[1]).strip()
+        if str(node.children[3]).strip() == '(':
+            # This means we are dealing with an import statement containing parentheses
+            # ex: from a import (b, c, d)
+            import_as_name = node.children[4]
+        else:
+            import_as_name = node.children[3]
+        if import_as_name.type == syms.import_as_names:
+            as_names = [child for child in import_as_name.children if str(child).strip() != ',']
+        else:
+            as_names = [import_as_name]
+        for child in as_names:
+            _, import_name, binding_name = handle_name(child)
+            imports.setdefault(package, set()).add(ImportPairing(import_name, binding_name))
+
+    return ImportNodeInfo(imports, node)

--- a/typewriter/fixes/tests/base_py2.py
+++ b/typewriter/fixes/tests/base_py2.py
@@ -227,6 +227,150 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             """
         self.check(a, b)
 
+    def test_type_by_mod_import_as(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "mod2.AnotherClass"},
+              }])
+        a = """\
+            import mod2 as bar
+            def nop(foo):
+                return bar.AnotherClass()
+            class MyClass: pass
+            """
+        b = """\
+            import mod2 as bar
+            def nop(foo):
+                # type: (MyClass) -> bar.AnotherClass
+                return bar.AnotherClass()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_type_by_dotted_import_as(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "pkg.mod2.AnotherClass"},
+              }])
+        a = """\
+            import pkg.mod2.AnotherClass as bar
+            def nop(foo):
+                return bar()
+            class MyClass: pass
+            """
+        b = """\
+            import pkg.mod2.AnotherClass as bar
+            def nop(foo):
+                # type: (MyClass) -> bar
+                return bar()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_type_by_dotted_import_mod_as(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "pkg.mod2.AnotherClass"},
+              }])
+        a = """\
+            import pkg.mod2 as bar
+            def nop(foo):
+                return bar.AnotherClass()
+            class MyClass: pass
+            """
+        b = """\
+            import pkg.mod2 as bar
+            def nop(foo):
+                # type: (MyClass) -> bar.AnotherClass
+                return bar.AnotherClass()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_type_by_import_as(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "mod2.AnotherClass"},
+              }])
+        a = """\
+            from mod2 import AnotherClass as bar
+            def nop(foo):
+                return bar()
+            class MyClass: pass
+            """
+        b = """\
+            from mod2 import AnotherClass as bar
+            def nop(foo):
+                # type: (MyClass) -> bar
+                return bar()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_type_by_from_import_as_with_dotted_package(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass"],
+                  "return_type": "pkg.mod2.AnotherClass"},
+              }])
+        a = """\
+            from pkg.mod2 import AnotherClass as bar
+            def nop(foo):
+                return bar()
+            class MyClass: pass
+            """
+        b = """\
+            from pkg.mod2 import AnotherClass as bar
+            def nop(foo):
+                # type: (MyClass) -> bar
+                return bar()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_parentheses_import(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod2.MyClass"],
+                  "return_type": "mod2.AnotherClass"},
+              }])
+        a = """\
+            from mod2 import (AnotherClass, MyClass)
+            def nop(foo):
+                return AnotherClass()
+            class MyClass: pass
+            """
+        b = """\
+            from mod2 import (AnotherClass, MyClass)
+            def nop(foo):
+                # type: (MyClass) -> AnotherClass
+                return AnotherClass()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
     def test_add_kwds(self):
         self.setTestData(
             [{"func_name": "nop",

--- a/typewriter/fixes/tests/test_util.py
+++ b/typewriter/fixes/tests/test_util.py
@@ -1,0 +1,119 @@
+""" Test suite for the code in fixer_utils """
+
+# Local imports
+from lib2to3.fixer_util import Attr, Call, Comma, Name, is_import, syms
+from lib2to3.pgen2 import token
+from lib2to3.pytree import Leaf, Node
+from lib2to3.tests.support import TestCase
+from lib2to3.tests.test_util import parse
+from typing import NamedTuple
+
+from .. import fixer_utils
+
+
+def _to_binding(node, type):
+    if node.type == type:
+        return node
+    if node.type == token.NAME:
+        return None
+    for child in node.children:
+        if child.type == type:
+            return child
+        res = _to_binding(child, type)
+        if res is not None and res.type == type:
+            return res
+
+
+class Test_get_import_info(TestCase):
+    def get_import_info(self, string):
+        node = parse(string)
+        for type in [syms.import_name, syms.import_from]:
+            n = _to_binding(node, type)
+            if n is not None:
+                node = n
+                break
+        return fixer_utils.get_import_info(node)
+
+    def test(self):
+        passing_tests = (({'': [('b', 'b')]}, "import b"),
+                         ({'': [('b', 'c')]}, "import b as c"),
+                         ({"a": [('b', 'a.b')]}, "import a.b"),
+                         ({"a.b": [('c', 'a.b.c')]}, "import a.b.c"),
+                         ({"a": [('b', 'c')]}, "import a.b as c"),
+                         ({"a.x": [('b', 'c')]}, "import a.x.b as c"),
+                         ({"a": [('b', 'b')]}, "from a import b"),
+                         ({"a": [('b', 'b'), ('c', 'c'), ('d', 'd')]}, "from a import b, c, d"),
+                         ({"a": [('b', 'b'), ('c', 'c'), ('d', 'd')]}, "from a import (b, c, d)"),
+                         ({"a": [('b', 'b'), ('c', 'c'), ('d', 'd')]}, "from a import (b,\nc,\nd)"),
+                         ({"a": [('b', 'c')]}, "from a import b as c"),
+                         ({"a.x": [('b', 'b')]}, "from a.x import b"),
+                         ({"a.x": [('b', 'c')]}, "from a.x import b as c"),
+                         ({"a": [('b', 'a.b')], "x": [('c', 'x.c')], "y": [('d', 'y.d')]},
+                          "import a.b, x.c, y.d"))
+        for imports, stmt in passing_tests:
+            print(stmt)
+            n = self.get_import_info(stmt)
+            self.assertTrue(n.imports)
+            for key in imports.keys():
+                self.assertTrue(n.imports.get(key))
+                ref = set(imports.get(key))
+                res = n.imports.get(key)
+                self.assertTrue(ref == res)
+
+
+class Test_find_import_info(TestCase):
+    def find_import_info(self, package, name, string):
+        node = parse(string)
+        return fixer_utils.find_import_info(package, name, node)
+
+    def test(self):
+        package, name, binding, string = ('mod2', 'AnotherClass', 'bar',
+                                          """
+                                          # Attempt to disguise as mod2.AnotherClass - before real import
+                                          import something as AnotherClass
+                                          import AnotherClass
+                                          import AnotherClass as other
+                                          import mod3.AnotherClass
+                                          import mod3.AnotherClass as thing
+                                          import mod2.stuff as AnotherClass
+                                          import mod3.mod2.AnotherClass
+                                          import mod3.mod2.AnotherClass as ox
+                                          import mod3.mod2.dingo as AnotherClass
+                                          from something import geese as AnotherClass
+                                          from AnotherClass import goober
+                                          from AnotherClass import goober as gobble
+                                          from mod3 import AnotherClass
+                                          from mod3 import AnotherClass as bucket
+                                          from mod2 import stuff as AnotherClass
+                                          from mod3.mod2 import AnotherClass
+                                          from mod3.mod2 import AnotherClass as trex
+                                          from mod3.mod2 import dingo as AnotherClass
+
+                                          # real import
+                                          import mod2.AnotherClass as bar
+
+                                          # Attempt to disguise as mod2.AnotherClass - after real import
+                                          import something2 as AnotherClass
+                                          import AnotherClass
+                                          import AnotherClass as other2
+                                          import mod4.AnotherClass
+                                          import mod4.AnotherClass as thing2
+                                          import mod2.stuff2 as AnotherClass
+                                          import mod4.mod2.AnotherClass
+                                          import mod4.mod2.AnotherClass as ox2
+                                          import mod4.mod2.dingo2 as AnotherClass
+                                          from something2 import geese2 as AnotherClass
+                                          from AnotherClass import goober2
+                                          from AnotherClass import goober2 as gobble2
+                                          from mod4 import AnotherClass
+                                          from mod4 import AnotherClass as bucket2
+                                          from mod4 import stuff2 as AnotherClass
+                                          from mod4.mod2 import AnotherClass
+                                          from mod4.mod2 import AnotherClass as trex2
+                                          from mod4.mod2 import dingo2 as AnotherClass""")
+
+        res = self.find_import_info(package, name, string)
+        self.assertTrue(res)
+        self.assertTrue(res.package == package)
+        self.assertTrue(res.entry == name)
+        self.assertTrue(res.binding == binding)


### PR DESCRIPTION
If a tool like `dmypy suggest` recommends, 

```
{
"func_name": "nop",
"path": "mod1.py",
"line": 1,
"signature": {
    "arg_types": ["mod1.MyClass"],
    "return_type": "mod2.AnotherClass"},
}
```
for the code
```
import mod2 as bar
def nop(foo):
    return bar.AnotherClass()
class MyClass: pass
```
We used to incorrectly annotate
```
import mod2 as bar
def nop(foo):
    # type: (MyClass) -> mod2.AnotherClass
    return bar.AnotherClass()
class MyClass: pass
```
But we now correctly annotate
```
import mod2 as bar
def nop(foo):
    # type: (MyClass) -> bar.AnotherClass
    return bar.AnotherClass()
class MyClass: pass
```

