### PR TITLE
Create TYPE_CHECKING block for new, unsafe imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ mypy_extensions>=0.3.0
 pytest>=3.3.0
 setuptools>=28.8.0
 six>=1.11.0
+kids.cache>=0.0.7
+typing-extensions>=3.7.4.3
 typing>=3.6.2; python_version < '3.5'
 mock>=4.0.2; python_version < '3.3'

--- a/typewriter/annotations/main.py
+++ b/typewriter/annotations/main.py
@@ -1,7 +1,9 @@
 """Main entry point to mypy annotation inference utility."""
 
 import json
-from typing import List, TypedDict
+from typing import List
+
+from typing_extensions import TypedDict
 
 from typewriter.annotations.infer import infer_annotation
 from typewriter.annotations.parse import parse_json

--- a/typewriter/annotations/parse.py
+++ b/typewriter/annotations/parse.py
@@ -8,7 +8,9 @@ The collect_types tool is in pyannotate_runtime/collect_types.py.
 import json
 import re
 import sys
-from typing import Any, List, Mapping, NoReturn, Set, Text, Tuple, TypedDict
+from typing import Any, List, Mapping, NoReturn, Set, Text, Tuple
+
+from typing_extensions import TypedDict
 
 from typewriter.annotations.types import (ARG_POS, ARG_STAR, ARG_STARSTAR,
                                           AbstractType, AnyType, Argument,

--- a/typewriter/fixes/tests/base_py3.py
+++ b/typewriter/fixes/tests/base_py3.py
@@ -103,8 +103,10 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             class MyClass: pass
             """
         b = """\
-            from mod2 import OtherClass
-            from mod3 import AnotherClass
+            import typing.TYPE_CHECKING
+            if typing.TYPE_CHECKING:
+                from mod2 import OtherClass
+                from mod3 import AnotherClass
             def nop(foo: MyClass, bar: OtherClass) -> AnotherClass:
                 return AnotherClass()
             class MyClass: pass

--- a/typewriter/fixes/tests/test_util.py
+++ b/typewriter/fixes/tests/test_util.py
@@ -126,3 +126,55 @@ class Test_find_import_info(TestCase):
         self.assertTrue(res.package == package)
         self.assertTrue(res.entry == name)
         self.assertTrue(res.binding == binding)
+
+
+class Test_create_type_checking_import(TestCase):
+    def create_type_checking_import(self, package, name, string):
+        node = parse(string)
+        fixer_utils.create_type_checking_import(package, name, node)
+        return node
+
+    def test(self):
+        string = """
+        import a
+        import b.a as c
+        import c.d as e
+        from X import Y
+
+        import Z as W
+
+        import typing.TYPE_CHECKING
+        if typing.TYPE_CHECKING:
+            from bar import R
+            from bar import S
+            from bar import T
+
+        import mod as bar
+        import foo
+        from foo.mod2 import MyClass
+        """
+
+        ref = """
+        import a
+        import b.a as c
+        import c.d as e
+        from X import Y
+
+        import Z as W
+
+        import typing.TYPE_CHECKING
+        if typing.TYPE_CHECKING:
+            from bar import R
+            from bar import S
+            from bar import T
+            from bar import TestImport
+
+        import mod as bar
+        import foo
+        from foo.mod2 import MyClass
+        """
+        ref = parse(ref)
+
+        res = self.create_type_checking_import("bar", "TestImport", string)
+        self.assertTrue(res)
+        self.assertTrue(res == ref)


### PR DESCRIPTION
Whereas before we added imports at the global level, now all *added* imports go under a `typing.TYPE_CHECKING` block - with the following exceptions:
1. The module of the import is the same as an import already in the global scope. ex: Say we need to import `mod2.Y`
```
from mod2 import X

....
```
would become
```
from mod2 import X
from mod2 import Y

....
```
but 
```
from mod1 import X

....
```
would become
```
from mod1 import X
import typing.TYPE_CHECKING
if typing.TYPE_CHECKING:
    from mod2 import Y

....
```
2. Any import from the `typing` module will be in the global scope since it de facto follows rule 1. i.e. in order to make a `typing.TYPE_CHECKING` block, we must import from the `typing` module at the global scope and therefore any other `typing import` would be placed at the global scope by rule 1.

Our imported TYPE_CHECKING and block will always directly follow the lowest global scope import to ensure no obvious issues with import ordering. If there are no global scope imports, it will follow the docstring. If there is no docstring it will be one the first line of the document.