### PR TITLE
Fixed TYPE_CHECKING import bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .tox
 /.idea
 .dmypy.json
+/venv/

--- a/typewriter/fixes/fixer_utils.py
+++ b/typewriter/fixes/fixer_utils.py
@@ -259,10 +259,7 @@ def _new_type_check_with_import(package, name, root, insert_pos):
     # if_stmt: 'if' namedexpr_test ':' suite ('elif' namedexpr_test ':' suite)* ['else' ':' suite]
     type_check_node = Node(syms.if_stmt,
                            [Leaf(token.NAME, 'if'),
-                            Node(syms.power, [Leaf(token.NAME, 'typing'),
-                                              Node(syms.trailer, [Leaf(token.DOT, '.'),
-                                                                  Leaf(token.NAME, 'TYPE_CHECKING')])],
-                                 prefix=" "),
+                            Leaf(token.NAME, 'TYPE_CHECKING', prefix=" "),
                             Leaf(token.COLON, ':'),
                             # [Grammar]
                             # suite: simple_stmt | NEWLINE INDENT stmt+ DEDENT
@@ -274,8 +271,8 @@ def _new_type_check_with_import(package, name, root, insert_pos):
 
     # We can just hardcode the correct insert position since we just created the typing block
     root.insert_child(insert_pos, type_check_node)
-    # Make sure to import typing.TYPE_CHECKING just before using
-    import_type_checking = [_generate_import_node(None, 'typing.TYPE_CHECKING'), Newline()]
+    # Make sure to import TYPE_CHECKING just before using
+    import_type_checking = [_generate_import_node('typing', 'TYPE_CHECKING'), Newline()]
     root.insert_child(insert_pos, Node(syms.simple_stmt, import_type_checking))
 
 

--- a/typewriter/fixes/tests/base_py2.py
+++ b/typewriter/fixes/tests/base_py2.py
@@ -219,8 +219,8 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             """
         b = """\
             from mod3 import AnotherClass
-            import typing.TYPE_CHECKING
-            if typing.TYPE_CHECKING:
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
                 from mod2 import OtherClass
             def nop(foo, bar):
                 # type: (MyClass, OtherClass) -> AnotherClass
@@ -435,8 +435,8 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
               }])
         a = """\
             from mod3 import AnotherClass
-            import typing.TYPE_CHECKING
-            if typing.TYPE_CHECKING:
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
                 import X
             def nop(foo):
                 return AnotherClass()
@@ -444,8 +444,8 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             """
         b = """\
             from mod3 import AnotherClass
-            import typing.TYPE_CHECKING
-            if typing.TYPE_CHECKING:
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
                 import X
                 from mod2 import MyClass
             def nop(foo):
@@ -1063,8 +1063,8 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
                 pass
             """
         b = """\
-            import typing.TYPE_CHECKING
-            if typing.TYPE_CHECKING:
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
                 from foo import A
             def nop(a):
                 # type: (A.B) -> None

--- a/typewriter/fixes/tests/base_py3.py
+++ b/typewriter/fixes/tests/base_py3.py
@@ -103,8 +103,8 @@ class AnnotateFromSignatureTestCase(FixerTestCase):
             class MyClass: pass
             """
         b = """\
-            import typing.TYPE_CHECKING
-            if typing.TYPE_CHECKING:
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
                 from mod2 import OtherClass
                 from mod3 import AnotherClass
             def nop(foo: MyClass, bar: OtherClass) -> AnotherClass:


### PR DESCRIPTION
Previously when inserting a `TYPE_CHECKING` import we were doing so in the invalid form

```
import typing.TYPE_CHECKING
if typing.TYPE_CHECKING:
   ...
```

now we do the correct import of

```
from typing import TYPE_CHECKING
if TYPE_CHECKING:
   ...
```

-----

Tests have been updated to reflect this change in expectation