### PR TITLE
Guarded typing_extensions by version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 /.idea
 .dmypy.json
 /venv/
+poetry.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: &exclude "tests/fixtures/.*"
 
 - repo: https://github.com/timothycrosley/isort
-  rev: '5.5.2'
+  rev: '5.12.0'
   hooks:
   - id: isort
     args: [--filter-files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,20 +31,20 @@ six = "*"
 docutils = "*"
 "kids.cache" = "*"
 typing = { version = "3.7.*", python = "<3.7" }
+typing-extensions = { version = ">=3.7.4.3", python = ">=3.7,<3.10" }
 
-pytest = { version = "^6.1", optional = true }
+
+pytest = { version = "^6.1", python = ">=3.5", optional = true }
 coverage = { version = "*", optional = true }
 pytest-mock = { version = "*", optional = true }
 mypy_extensions = { version = ">=0.3.0", optional = true }
-typing-extensions = { version = ">=3.7.4.3", optional = true }
 
 [tool.poetry.extras]
 tests = [
     "pytest",
     "coverage",
     "pytest-mock",
-    "mypy_extensions",
-    "typing-extensions"
+    "mypy_extensions"
 ]
 
 [tool.poetry.dev-dependencies]

--- a/typeright/annotations/main.py
+++ b/typeright/annotations/main.py
@@ -1,9 +1,13 @@
 """Main entry point to mypy annotation inference utility."""
 
 import json
+import sys
 from typing import List
 
-from typing_extensions import TypedDict
+if sys.version_info[:2] < (3, 10):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 from typeright.annotations.infer import infer_annotation
 from typeright.annotations.parse import parse_json

--- a/typeright/annotations/parse.py
+++ b/typeright/annotations/parse.py
@@ -10,12 +10,15 @@ import re
 import sys
 from typing import Any, List, Mapping, NoReturn, Set, Text, Tuple
 
-from typing_extensions import TypedDict
+if sys.version_info[:2] < (3, 10):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 from typeright.annotations.types import (ARG_POS, ARG_STAR, ARG_STARSTAR,
-                                          AbstractType, AnyType, Argument,
-                                          ClassType, NoReturnType, TupleType,
-                                          UnionType)
+                                         AbstractType, AnyType, Argument,
+                                         ClassType, NoReturnType, TupleType,
+                                         UnionType)
 
 PY2 = sys.version_info < (3,)
 


### PR DESCRIPTION
- Added version guards appropriate to typing_extensions
- Made typing_extensions a required import for versions 3.7-3.9.* to match the version guards
- Added poetry.lock to the gitignore